### PR TITLE
[29] fix health visibility

### DIFF
--- a/libs/common-endpoints/README.md
+++ b/libs/common-endpoints/README.md
@@ -1,3 +1,5 @@
+![CI](https://github.com/akatsuki-members/credit-crypto/actions/workflows/common-endpoints.yaml/badge.svg?branch=dev) ![GitHub release](https://img.shields.io/github/release/akatsuki-members/credit-crypto/all.svg?style=plastic)
+
 # common-endpoints
 
 It provides a set of common endpoint for apps and microservices.

--- a/libs/common-endpoints/pkg/endpoints/endpoint.go
+++ b/libs/common-endpoints/pkg/endpoints/endpoint.go
@@ -7,6 +7,21 @@ import (
 	"github.com/akatsuki-members/credit-crypto/libs/common-endpoints/internal/handlers/heartbeat"
 )
 
+// HealthChecker function type to check service health
+type HealthChecker func() Report
+
+// Item contains information about components and their status.
+type Item struct {
+	Name    string `json:"name"`    // integration or component name
+	Healthy bool   `json:"healthy"` // health status of the component.
+}
+
+// Contains health report
+type Report struct {
+	Healthy bool   `json:"healthy"`          // The service is healthy
+	Data    []Item `json:"report,omitempty"` // health report
+}
+
 type handler struct {
 	router       *http.ServeMux
 	hasEndpoints bool
@@ -25,8 +40,25 @@ func (h *handler) WithHeartbeat() *handler {
 	return h
 }
 
-func (h *handler) WithHealth(checker health.HealthChecker) *handler {
+func (h *handler) WithHealth(checker HealthChecker) *handler {
 	h.hasEndpoints = true
-	health.Add(h.router, checker)
+	health.Add(h.router, h.newHealthChecker(checker))
 	return h
+}
+
+func (h *handler) newHealthChecker(checker HealthChecker) health.HealthChecker {
+	return func() health.Report {
+		result := checker()
+		report := make([]health.Item, len(result.Data))
+		for idx, v := range result.Data {
+			report[idx] = health.Item{
+				Name:    v.Name,
+				Healthy: v.Healthy,
+			}
+		}
+		return health.Report{
+			Healthy: result.Healthy,
+			Data:    report,
+		}
+	}
 }

--- a/libs/common-endpoints/pkg/endpoints/endpoint_test.go
+++ b/libs/common-endpoints/pkg/endpoints/endpoint_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/akatsuki-members/credit-crypto/libs/common-endpoints/internal/handlers"
-	"github.com/akatsuki-members/credit-crypto/libs/common-endpoints/internal/handlers/health"
 	"github.com/akatsuki-members/credit-crypto/libs/common-endpoints/pkg/endpoints"
 	"github.com/stretchr/testify/assert"
 )
@@ -31,7 +30,7 @@ func TestHeartbeat(t *testing.T) {
 
 func TestHealth(t *testing.T) {
 	expectedCode := 200
-	expectedHealth := []health.Item{
+	expectedHealth := []endpoints.Item{
 		{Name: "Database", Healthy: true},
 		{Name: "Cache", Healthy: true},
 		{Name: "OtherService", Healthy: true},
@@ -87,17 +86,17 @@ func (h *httpHandlerMock) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusAccepted)
 }
 
-func newMockedHealthChecker(report []health.Item, healthy bool) func() health.Report {
-	return func() health.Report {
-		return health.Report{
+func newMockedHealthChecker(report []endpoints.Item, healthy bool) func() endpoints.Report {
+	return func() endpoints.Report {
+		return endpoints.Report{
 			Healthy: healthy,
 			Data:    report,
 		}
 	}
 }
 
-func newHealthReportOK() []health.Item {
-	return []health.Item{
+func newHealthReportOK() []endpoints.Item {
+	return []endpoints.Item{
 		{Name: "Database", Healthy: true},
 		{Name: "Cache", Healthy: true},
 		{Name: "OtherService", Healthy: true},
@@ -118,7 +117,7 @@ func decodeHealthResponse(t *testing.T, res *http.Response) handlers.Result {
 		t.Errorf("unexpected error, %s", err)
 		t.FailNow()
 	}
-	var items []health.Item
+	var items []endpoints.Item
 	err = json.Unmarshal(resultData, &items)
 	if err != nil {
 		t.Errorf("unexpected error, %s", err)


### PR DESCRIPTION
* problem: health logic is inside an internal package and endpoints package is asking for health.Report and health.HealthChecker, those won't be visible for other projects, so it could not be used by other projects.
* solution: create own structs that can be visible for othe projects.