### PR TITLE
[30] add info endpoint

### DIFF
--- a/libs/common-endpoints/README.md
+++ b/libs/common-endpoints/README.md
@@ -49,10 +49,17 @@ func(http.ResponseWriter, *http.Request)
 ```go
 import "github.com/akatsuki-members/credit-crypto/libs/common-endpoints/internal/handlers/health"
 import "github.com/akatsuki-members/credit-crypto/libs/common-endpoints/internal/handlers/heartbeat"
+import "github.com/akatsuki-members/credit-crypto/libs/common-endpoints/internal/handlers/info"
 ...
 mux := http.NewServeMux()
 ...
-endpoints.New(mux).WithHeartbeat().WithHealth(newHypotheticalHealthChecker()).WithInfo()
+infoData := endpoints.Info{
+	Name:    "audit-app",
+	Commit:  "963e91b",
+	Version: "1.5.3",
+}
+...
+endpoints.New(mux).WithHeartbeat().WithHealth(newHypotheticalHealthChecker()).WithInfo(infoData)
 ...
 func newHypotheticalHealthChecker() func() health.Report {
     // add your health logic here
@@ -67,11 +74,12 @@ func newHypotheticalHealthChecker() func() health.Report {
 ...
 func checkIntegrations() ([]health.Item, bool) {
     healthy := true
-    report := []health.Item{
+    report := []endpoints.Item{
 		{Name: "Database", Healthy: true},
 		{Name: "Cache", Healthy: true},
 		{Name: "OtherService", Healthy: true},
 	}
     return report, healthy
 }
+...
 ```

--- a/libs/common-endpoints/internal/handlers/info/info.go
+++ b/libs/common-endpoints/internal/handlers/info/info.go
@@ -1,1 +1,47 @@
 package info
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/akatsuki-members/credit-crypto/libs/common-endpoints/internal/handlers"
+)
+
+const infoPattern = "/info"
+
+// Report contains metadata related to the service
+type Report struct {
+	Name    string
+	Commit  string
+	Version string
+}
+
+func Add(router handlers.Router, infoData Report) {
+	router.HandleFunc(infoPattern, newInfoHandler(infoData))
+}
+
+func newInfoHandler(infoData Report) func(rw http.ResponseWriter, req *http.Request) {
+	return func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+		rw.Header().Add("content-type", "application/json")
+		err := json.NewEncoder(rw).Encode(newResult(infoData))
+		if err != nil {
+			log.Println("info report cannot be generated", err.Error(), "info", infoData)
+		}
+	}
+}
+
+func newResult(data Report) handlers.Result {
+	return handlers.Result{
+		Success: true,
+		Data:    data,
+	}
+}
+
+func newBadResult() handlers.Result {
+	return handlers.Result{
+		Success: false,
+		Errors:  []string{"cannot get info data"},
+	}
+}

--- a/libs/common-endpoints/internal/handlers/info/info_test.go
+++ b/libs/common-endpoints/internal/handlers/info/info_test.go
@@ -1,1 +1,69 @@
 package info_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/akatsuki-members/credit-crypto/libs/common-endpoints/internal/handlers"
+	"github.com/akatsuki-members/credit-crypto/libs/common-endpoints/internal/handlers/info"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddInfo(t *testing.T) {
+	// GIVEN
+	expectedCode := http.StatusOK
+	infoReport := info.Report{
+		Name:    "audit-app",
+		Commit:  "963e91b",
+		Version: "1.5.8",
+	}
+	expectedResult := handlers.Result{
+		Success: true,
+		Data:    infoReport,
+	}
+	mux := http.NewServeMux()
+
+	// WHEN
+	info.Add(mux, infoReport)
+	code, result := serve(t, mux)
+
+	// THEN
+	assert.Equal(t, expectedCode, code)
+	assert.Equal(t, expectedResult, result)
+}
+
+func serve(t *testing.T, mux *http.ServeMux) (int, handlers.Result) {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodGet, "/info", nil)
+	response := httptest.NewRecorder()
+
+	mux.ServeHTTP(response, request)
+	got, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Errorf("unexpected error reading info body: %s", err)
+		t.FailNow()
+	}
+	var result handlers.Result
+	err = json.Unmarshal(got, &result)
+	if err != nil {
+		t.Errorf("unexpected error unmarshalling info response: %s", err)
+		t.FailNow()
+	}
+	bytes, err := json.Marshal(result.Data)
+	if err != nil {
+		t.Errorf("unexpected error mrshalling result.Data response: %s", err)
+		t.FailNow()
+	}
+	var infoReport info.Report
+	err = json.Unmarshal(bytes, &infoReport)
+	if err != nil {
+		t.Errorf("unexpected error unmarshalling info response: %s", err)
+		t.FailNow()
+	}
+	result.Data = infoReport
+
+	return response.Code, result
+}

--- a/libs/common-endpoints/pkg/endpoints/endpoint.go
+++ b/libs/common-endpoints/pkg/endpoints/endpoint.go
@@ -5,10 +5,18 @@ import (
 
 	"github.com/akatsuki-members/credit-crypto/libs/common-endpoints/internal/handlers/health"
 	"github.com/akatsuki-members/credit-crypto/libs/common-endpoints/internal/handlers/heartbeat"
+	"github.com/akatsuki-members/credit-crypto/libs/common-endpoints/internal/handlers/info"
 )
 
 // HealthChecker function type to check service health
 type HealthChecker func() Report
+
+// Info contains service information data
+type Info struct {
+	Name    string `json:"name"`
+	Commit  string `json:"commit"` // commit hash
+	Version string `json:"version"`
+}
 
 // Item contains information about components and their status.
 type Item struct {
@@ -34,15 +42,28 @@ func New(router *http.ServeMux) *handler {
 	return &newHandler
 }
 
+// WithHeartbeat add heartbeat endpoint to the service.
 func (h *handler) WithHeartbeat() *handler {
 	h.hasEndpoints = true
 	heartbeat.Add(h.router)
 	return h
 }
 
+// WithHealth add health endpoint to the service.
 func (h *handler) WithHealth(checker HealthChecker) *handler {
 	h.hasEndpoints = true
 	health.Add(h.router, h.newHealthChecker(checker))
+	return h
+}
+
+func (h *handler) WithInfo(data Info) *handler {
+	h.hasEndpoints = true
+	infoReport := info.Report{
+		Name:    data.Name,
+		Commit:  data.Commit,
+		Version: data.Version,
+	}
+	info.Add(h.router, infoReport)
 	return h
 }
 


### PR DESCRIPTION
* problem: service should show some metadata to know quickly what version is installed in the environment.
* solution: add an info endpoint.