### PR TITLE
[39] add pubsub core lib

### DIFF
--- a/.github/workflows/pubsub.yaml
+++ b/.github/workflows/pubsub.yaml
@@ -1,0 +1,39 @@
+# This workflow will test pubsub project
+
+name: pubsub-ci
+
+on:
+  push:
+    branches:
+      - "dev"
+    paths:
+      - "./libs/pubsub/**"
+      - ".github/workflows/pubsub.yaml"
+  pull_request:
+    branches:
+      - "dev"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ''
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.17.x
+      - name: Cache Go Build
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-gops-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-gops-
+      - name: Test lib pubsub
+        run: |-
+          cd ./libs/pubsub
+          go test -race ./...

--- a/libs/common-endpoints/Makefile
+++ b/libs/common-endpoints/Makefile
@@ -1,2 +1,5 @@
 test:
 	go test -race ./...
+
+lint-docker:
+	docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.47-alpine golangci-lint run -v --enable-all

--- a/libs/pubsub/.golangci.yml
+++ b/libs/pubsub/.golangci.yml
@@ -1,0 +1,32 @@
+run:
+  # Include test files or not.
+  # Default: true
+  tests: true
+linters:
+  enable-all: true
+  disable:
+    - exhaustive
+    - exhaustivestruct
+    - exhaustruct
+    - interfacer
+    - scopelint
+    - maligned
+    - golint
+linters-settings:
+  tagliatelle:
+    # Check the struck tag name case.
+    case:
+      # Use the struct field name to check the name of the struct tag.
+      # Default: false
+      use-field-name: false
+      rules:
+        # Any struct tag type can be used.
+        # Support string case: `camel`, `pascal`, `kebab`, `snake`, `goCamel`, `goPascal`, `goKebab`, `goSnake`, `upper`, `lower`
+        json:     snake
+        yaml:     camel
+        xml:      snake
+        whatever: kebab
+  lll:
+    # max line length, lines longer will be reported. Default is 120.
+    # '\t' is counted as 1 character by default, and can be changed with the tab-width option
+    line-length: 100

--- a/libs/pubsub/Makefile
+++ b/libs/pubsub/Makefile
@@ -1,0 +1,9 @@
+PWD = $(shell pwd)
+test:
+	go test -race ./...
+
+lint-docker:
+	docker run --rm -v $(PWD):/app -w /app golangci/golangci-lint:v1.47-alpine golangci-lint run
+
+lint-docker-verbose:
+	docker run --rm -v $(PWD):/app -w /app golangci/golangci-lint:v1.47-alpine golangci-lint run -v

--- a/libs/pubsub/README.md
+++ b/libs/pubsub/README.md
@@ -1,0 +1,79 @@
+![CI](https://github.com/akatsuki-members/credit-crypto/actions/workflows/pubsub.yaml/badge.svg?branch=dev) ![GitHub release](https://img.shields.io/github/release/akatsuki-members/credit-crypto/all.svg?style=plastic)
+
+# pubsub
+
+This library defines the logic for publishing and subscribing to an event bus.
+
+## How to build?
+
+this is a library, we are not going to build it.
+
+## How to test?
+
+there are two options to test this library.
+
+* running go tool
+
+```sh
+go test -race ./...
+```
+
+* running make
+
+```sh
+make test
+```
+
+## How to check with linter?
+
+* running local using docker
+
+```sh
+make lint-docker 
+```
+
+* running local using docker and verbose
+
+```sh
+make lint-docker-verbose
+```
+
+## How to use?
+
+## Known issues with linter
+
+1.  File is not `gci`-ed with --skip-generated -s standard,default (gci)
+
+if you are doing static analysis with golangci-lint and you see this issue:
+
+```log
+File is not `gci`-ed with --skip-generated -s standard,default (gci)
+```
+
+you can fix it installing [gci](https://github.com/daixiang0/gci)
+
+```sh
+go install github.com/daixiang0/gci@latest
+```
+
+and run this command over the file with the issue.
+
+```sh
+$ gci -w main.go
+```
+
+other source [here](https://github.com/golangci/golangci-lint/issues/1942)
+
+2. File is not `gofumpt`-ed (gofumpt)
+
+you can fix it installing [gofumpt](https://github.com/mvdan/gofumpt)
+
+```sh
+go install mvdan.cc/gofumpt@latest
+```
+
+and run this command over the file with the issue.
+
+```sh
+$ gofumpt -l -w subscribers/subscriber.go
+```

--- a/libs/pubsub/go.mod
+++ b/libs/pubsub/go.mod
@@ -1,0 +1,14 @@
+module github.com/akatsuki-members/credit-crypto/libs/pubsub
+
+go 1.17
+
+require (
+	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.8.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/libs/pubsub/go.sum
+++ b/libs/pubsub/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/libs/pubsub/internal/adapters/doc.go
+++ b/libs/pubsub/internal/adapters/doc.go
@@ -1,0 +1,2 @@
+// Package adapters contains a set of packages that provide adapters to different event buses.
+package adapters

--- a/libs/pubsub/internal/adapters/kafka/doc.go
+++ b/libs/pubsub/internal/adapters/kafka/doc.go
@@ -1,0 +1,2 @@
+// Package kafka provides logic to publishing and subscribing to a kafka event bus.
+package kafka

--- a/libs/pubsub/internal/adapters/kinesis/doc.go
+++ b/libs/pubsub/internal/adapters/kinesis/doc.go
@@ -1,0 +1,2 @@
+// Package kinesis provides logic to publishing and subscribing to an aws kinesis event bus.
+package kinesis

--- a/libs/pubsub/internal/adapters/nats/doc.go
+++ b/libs/pubsub/internal/adapters/nats/doc.go
@@ -1,0 +1,2 @@
+// Package nats provides logic to publishing and subscribing to a nats event bus.
+package nats

--- a/libs/pubsub/internal/adapters/sns/doc.go
+++ b/libs/pubsub/internal/adapters/sns/doc.go
@@ -1,0 +1,2 @@
+// Package sns provides logic to publishing and subscribing to an aws sns event bus.
+package sns

--- a/libs/pubsub/internal/adapters/sqs/doc.go
+++ b/libs/pubsub/internal/adapters/sqs/doc.go
@@ -1,0 +1,2 @@
+// Package sqs provides logic to publishing and subscribing to an aws sqs event bus.
+package sqs

--- a/libs/pubsub/messages/doc.go
+++ b/libs/pubsub/messages/doc.go
@@ -1,0 +1,2 @@
+// Package messages provides logic related to event messages.
+package messages

--- a/libs/pubsub/messages/message.go
+++ b/libs/pubsub/messages/message.go
@@ -1,0 +1,17 @@
+package messages
+
+// Header contains event metadata.
+type Header struct {
+	ID          string // id correlation id.
+	Domain      string // domain the business domain of the message.
+	EventType   string // EventType within the domain what type of event it is.
+	Version     string // Version it is the event type version.
+	Application string // AppName name of the sender application
+	MessageID   string // MessageID id used for message acknowledge.
+}
+
+// Event contains data related to the event.
+type Event struct {
+	Header Header
+	Data   []byte
+}

--- a/libs/pubsub/publishers/doc.go
+++ b/libs/pubsub/publishers/doc.go
@@ -1,0 +1,2 @@
+// Package publishers provides behavior related to publishing events into an event bus.
+package publishers

--- a/libs/pubsub/publishers/publisher.go
+++ b/libs/pubsub/publishers/publisher.go
@@ -1,0 +1,57 @@
+package publishers
+
+import (
+	"context"
+	"log"
+
+	"github.com/akatsuki-members/credit-crypto/libs/pubsub/messages"
+	"github.com/pkg/errors"
+)
+
+// EventBusPublisher defines event bus publishing behavior.
+type EventBusPublisher interface {
+	// Publish push given event into an event bus in the given message channel.
+	Publish(ctx context.Context, messageChannel string, message interface{}) error
+}
+
+// EventMessage defines message event and direction.
+type EventMessage struct {
+	// ChannelName the name of the topic or queue.
+	ChannelName string
+	// Event event to publish into the event bus.
+	Event messages.Event
+}
+
+// Publisher define publishing data and logic.
+type Publisher struct {
+	eventBus EventBusPublisher
+}
+
+const (
+	publishingErrorMessage = "could not publish event"
+)
+
+// New instaces a new publisher.
+func New(eventBus EventBusPublisher) *Publisher {
+	newEventBus := Publisher{
+		eventBus: eventBus,
+	}
+
+	return &newEventBus
+}
+
+// Publish push given event into the given channel.
+func (p *Publisher) Publish(ctx context.Context, event EventMessage) error {
+	err := p.eventBus.Publish(ctx, event.ChannelName, event.Event)
+	if err != nil {
+		log.Println(
+			"error", "something went wrong pushing event",
+			"content", event,
+			"method", "publishers.Publisher.Publish",
+		)
+
+		return errors.Wrap(err, publishingErrorMessage)
+	}
+
+	return nil
+}

--- a/libs/pubsub/publishers/publisher_test.go
+++ b/libs/pubsub/publishers/publisher_test.go
@@ -1,0 +1,109 @@
+package publishers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/akatsuki-members/credit-crypto/libs/pubsub/messages"
+	"github.com/akatsuki-members/credit-crypto/libs/pubsub/publishers"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPublishSuccess(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	ctx := context.TODO()
+	expectedMessageChannel := "orders-topic"
+	expectedEvent := messages.Event{
+		Header: messages.Header{
+			ID:          "123-456-789",
+			Domain:      "loans",
+			EventType:   "orders",
+			Version:     "0.1.0",
+			Application: "core-app",
+		},
+		Data: []byte(`{"value_one": "one", "value_two": "two"}`),
+	}
+	event := eventMessageFixture()
+	eventBus := new(eventBusMock)
+	publisher := publishers.New(eventBus)
+	// When
+	err := publisher.Publish(ctx, event)
+	// Then
+	assert.NoError(t, err)
+	assert.Equal(t, expectedEvent, eventBus.message)
+	assert.Equal(t, expectedMessageChannel, eventBus.messageChannel)
+}
+
+func TestPublishFailed(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	ctx := context.TODO()
+	expectedError := errors.New("could not publish event: : error")
+	expectedMessageChannel := "orders-topic"
+	expectedEvent := messages.Event{
+		Header: messages.Header{
+			ID:          "123-456-789",
+			Domain:      "loans",
+			EventType:   "orders",
+			Version:     "0.1.0",
+			Application: "core-app",
+		},
+		Data: []byte(`{"value_one": "one", "value_two": "two"}`),
+	}
+	event := eventMessageFixture()
+	anError := errors.New("error")
+	eventBus := new(eventBusMock).withError(anError)
+	publisher := publishers.New(eventBus)
+	// When
+	err := publisher.Publish(ctx, event)
+	// Then
+	if !assert.NotNil(t, err) {
+		t.Fatalf("expected error but it was nil")
+	}
+
+	assert.Equal(t, expectedError.Error(), err.Error())
+	assert.Equal(t, expectedEvent, eventBus.message)
+	assert.Equal(t, expectedMessageChannel, eventBus.messageChannel)
+}
+
+type eventBusMock struct {
+	err            error
+	messageChannel string
+	message        interface{}
+}
+
+func (e *eventBusMock) withError(err error) *eventBusMock {
+	e.err = err
+
+	return e
+}
+
+func (e *eventBusMock) Publish(_ context.Context, channel string, message interface{}) error {
+	e.messageChannel = channel
+	e.message = message
+
+	return errors.Wrap(e.err, "")
+}
+
+func eventMessageFixture() publishers.EventMessage {
+	header := messages.Header{
+		ID:          "123-456-789",
+		Domain:      "loans",
+		EventType:   "orders",
+		Version:     "0.1.0",
+		Application: "core-app",
+	}
+	event := publishers.EventMessage{
+		Event: messages.Event{
+			Header: header,
+			Data:   []byte(`{"value_one": "one", "value_two": "two"}`),
+		},
+		ChannelName: "orders-topic",
+	}
+
+	return event
+}

--- a/libs/pubsub/subscribers/doc.go
+++ b/libs/pubsub/subscribers/doc.go
@@ -1,0 +1,3 @@
+// Package subscribers provides behavior related to subscribing to an event bus to listen
+// for new events.
+package subscribers

--- a/libs/pubsub/subscribers/subscriber.go
+++ b/libs/pubsub/subscribers/subscriber.go
@@ -1,0 +1,84 @@
+package subscribers
+
+import (
+	"context"
+
+	"github.com/akatsuki-members/credit-crypto/libs/pubsub/messages"
+	"github.com/pkg/errors"
+)
+
+type EventBusSubscriber interface {
+	// Pull pull a group of messages from event bus.
+	Pull(ctx context.Context, numberOfMessages uint8) ([]messages.Event, error)
+	Stream(ctx context.Context) (<-chan messages.Event, error)
+	Subscribe(ctx context.Context, channel string) error
+	Acknowledge(ctx context.Context, ID string) error
+}
+
+type Subscriber struct {
+	eventBus        EventBusSubscriber
+	channel         string
+	messagesPerPull uint8
+}
+
+type Settings struct {
+	EventBus        EventBusSubscriber
+	MessagesPerPull uint8
+}
+
+var errNoChannelName = errors.New("must provide a channel name")
+
+func New(settings Settings) *Subscriber {
+	newSubscriber := Subscriber{
+		eventBus:        settings.EventBus,
+		channel:         "",
+		messagesPerPull: settings.MessagesPerPull,
+	}
+
+	return &newSubscriber
+}
+
+func (s *Subscriber) Subscribe(ctx context.Context, channel string) error {
+	if channel == "" {
+		return errNoChannelName
+	}
+
+	err := s.eventBus.Subscribe(ctx, channel)
+	if err != nil {
+		return errors.WithMessagef(err, "unexpected error subscribing to channel %q", channel)
+	}
+
+	s.channel = channel
+
+	return nil
+}
+
+// Pull calls the event bus pull method to get the configured number of messages.
+func (s *Subscriber) Pull(ctx context.Context) ([]messages.Event, error) {
+	result, err := s.eventBus.Pull(ctx, s.messagesPerPull)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "unexpected error pulling messages from %q", s.channel)
+	}
+
+	return result, nil
+}
+
+// Stream calls the event bus stream method to get a stream of events.
+func (s *Subscriber) Stream(ctx context.Context) (<-chan messages.Event, error) {
+	stream, err := s.eventBus.Stream(ctx)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "unexpected error streaming messages from %q", s.channel)
+	}
+
+	return stream, nil
+}
+
+// Acknowledge acknowledge a given message id to avoid processing it again.
+func (s *Subscriber) Acknowledge(ctx context.Context, messageID string) error {
+	err := s.eventBus.Acknowledge(ctx, messageID)
+	if err != nil {
+		return errors.WithMessagef(err, "unexpected error acknowledging message: %q", messageID)
+	}
+
+	return nil
+}

--- a/libs/pubsub/subscribers/subscriber_test.go
+++ b/libs/pubsub/subscribers/subscriber_test.go
@@ -1,0 +1,372 @@
+package subscribers_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/akatsuki-members/credit-crypto/libs/pubsub/messages"
+	"github.com/akatsuki-members/credit-crypto/libs/pubsub/subscribers"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubscribeAndPull(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	expectedMessageChannel := "orders-topic"
+	expectedEvent := messages.Event{
+		Header: messages.Header{
+			ID:          "123-456-789",
+			Domain:      "loans",
+			EventType:   "orders",
+			Version:     "0.1.0",
+			Application: "core-app",
+			MessageID:   "1",
+		},
+		Data: []byte(`{"value_one": "one", "value_two": "two"}`),
+	}
+	events := []messages.Event{eventMessageFixture()}
+	ctx := context.TODO()
+	pullArgs := subscriberData{
+		t:               t,
+		messagesPerPull: 1,
+		eventBus:        new(eventBusMock).withEvents(events),
+		channel:         "orders-topic",
+	}
+	// When
+	got, err := subscribeAndPull(ctx, pullArgs)
+	// Then
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMessageChannel, pullArgs.eventBus.messageChannel)
+	assert.Equal(t, expectedEvent, got[0])
+}
+
+func TestSubscribeAndStream(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	expectedMessageChannel := "orders-topic"
+	expectedEvents := eventMessagesFixture()
+	events := eventMessagesFixture()
+	ctx, cancel := context.WithTimeout(context.TODO(), 2*time.Second)
+
+	defer cancel()
+
+	pullArgs := subscriberData{
+		t:                t,
+		eventBus:         new(eventBusMock).withEvents(events).withEventStream(),
+		channel:          "orders-topic",
+		expectedMessages: 2,
+	}
+	// When
+	got, err := subscribeAndStream(ctx, pullArgs)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	// Then
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMessageChannel, pullArgs.eventBus.messageChannel)
+	assert.Equal(t, expectedEvents, got)
+}
+
+func TestSubscribeAndPullAndAcknowledge(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	events := []messages.Event{eventMessageFixture()}
+	ctx := context.TODO()
+	pullArgs := subscriberData{
+		t:               t,
+		messagesPerPull: 1,
+		eventBus:        new(eventBusMock).withEvents(events),
+		channel:         "orders-topic",
+	}
+	// When
+	acknowledgeErrors := pullAndAcknowledge(ctx, pullArgs)
+	// Then
+	assert.Empty(t, acknowledgeErrors)
+}
+
+func TestSubscribeAndError(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	expectedError := errors.New(`unexpected error subscribing to channel "orders-topic": error`)
+	errToReturn := errors.New("error")
+	ctx := context.TODO()
+	pullArgs := subscriberData{
+		t:               t,
+		messagesPerPull: 1,
+		eventBus:        new(eventBusMock).withSubscribeError(errToReturn),
+		channel:         "orders-topic",
+	}
+	// When
+	_, err := subscribeAndPull(ctx, pullArgs)
+	// Then
+	assert.Error(t, err)
+	assert.Equal(t, expectedError.Error(), err.Error())
+}
+
+func TestPullAndError(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	expectedError := errors.New(`unexpected error pulling messages from "orders-topic": error`)
+	errToReturn := errors.New("error")
+	ctx := context.TODO()
+	pullArgs := subscriberData{
+		t:               t,
+		messagesPerPull: 1,
+		eventBus:        new(eventBusMock).withPullError(errToReturn),
+		channel:         "orders-topic",
+	}
+	// When
+	_, err := subscribeAndPull(ctx, pullArgs)
+	// Then
+	assert.Error(t, err)
+	assert.Equal(t, expectedError.Error(), err.Error())
+}
+
+func pullAndAcknowledge(ctx context.Context, args subscriberData) []error {
+	args.t.Helper()
+
+	settings := subscribers.Settings{
+		EventBus:        args.eventBus,
+		MessagesPerPull: args.messagesPerPull,
+	}
+	subscriber := subscribers.New(settings)
+
+	err := subscriber.Subscribe(ctx, args.channel)
+	if err != nil {
+		args.t.Fatalf("unexpected error: %s", err)
+	}
+
+	events, err := subscriber.Pull(ctx)
+	if err != nil {
+		args.t.Fatalf("unexpected error: %s", err)
+	}
+
+	if len(events) == 0 {
+		args.t.Fatal("events were expected but got zero")
+	}
+
+	var acknowledgeErrors []error
+
+	for idx := range events {
+		err := subscriber.Acknowledge(ctx, events[idx].Header.MessageID)
+		if err != nil {
+			acknowledgeErrors = append(acknowledgeErrors, err)
+		}
+	}
+
+	return acknowledgeErrors
+}
+
+func subscribeAndPull(ctx context.Context, args subscriberData) ([]messages.Event, error) {
+	args.t.Helper()
+
+	subscriber, err := subscribe(ctx, args)
+	if err != nil {
+		return nil, errors.New(err.Error())
+	}
+
+	events, err := subscriber.Pull(ctx)
+	if args.eventBus.errPull != nil && err == nil {
+		args.t.Fatalf("unexpected error: %s", err)
+	}
+
+	if args.eventBus.errPull != nil && err != nil {
+		return nil, errors.New(err.Error())
+	}
+
+	return events, nil
+}
+
+func subscribeAndStream(ctx context.Context, args subscriberData) ([]messages.Event, error) {
+	args.t.Helper()
+
+	subscriber, err := subscribe(ctx, args)
+	if err != nil {
+		return nil, errors.New(err.Error())
+	}
+
+	stream, err := subscriber.Stream(ctx)
+	if args.eventBus.errStream != nil && err == nil {
+		args.t.Fatalf("unexpected error: %s", err)
+	}
+
+	if args.eventBus.errStream != nil && err != nil {
+		return nil, errors.New(err.Error())
+	}
+
+	var result []messages.Event
+
+	for i := uint8(0); i < args.expectedMessages; i++ {
+		select {
+		case <-ctx.Done():
+			return result, nil
+		case newEvent, ok := <-stream:
+			if !ok {
+				break
+			}
+
+			result = append(result, newEvent)
+		}
+	}
+
+	return result, nil
+}
+
+func subscribe(ctx context.Context, args subscriberData) (*subscribers.Subscriber, error) {
+	args.t.Helper()
+
+	settings := subscribers.Settings{
+		EventBus:        args.eventBus,
+		MessagesPerPull: args.messagesPerPull,
+	}
+	subscriber := subscribers.New(settings)
+
+	err := subscriber.Subscribe(ctx, args.channel)
+	if args.eventBus.errSubscribe != nil && err == nil {
+		args.t.Fatalf("unexpected error: %s", err)
+	}
+
+	if args.eventBus.errSubscribe != nil && err != nil {
+		return nil, errors.New(err.Error())
+	}
+
+	return subscriber, nil
+}
+
+var errStreamNotInitialized = errors.New("a stream must initialized first")
+
+type subscriberData struct {
+	t                *testing.T
+	messagesPerPull  uint8
+	expectedMessages uint8
+	eventBus         *eventBusMock
+	channel          string
+}
+
+func eventMessageFixture() messages.Event {
+	header := messages.Header{
+		ID:          "123-456-789",
+		Domain:      "loans",
+		EventType:   "orders",
+		Version:     "0.1.0",
+		Application: "core-app",
+		MessageID:   "1",
+	}
+	data := []byte(`{"value_one": "one", "value_two": "two"}`)
+	event := messages.Event{
+		Header: header,
+		Data:   data,
+	}
+
+	return event
+}
+
+func eventMessagesFixture() []messages.Event {
+	events := []messages.Event{
+		{
+			Header: messages.Header{
+				ID:          "123-456-789",
+				Domain:      "loans",
+				EventType:   "orders",
+				Version:     "0.1.0",
+				Application: "core-app",
+				MessageID:   "1",
+			},
+			Data: []byte(`{"value_one": "one", "value_two": "two"}`),
+		},
+		{
+			Header: messages.Header{
+				ID:          "123-456-790",
+				Domain:      "loans",
+				EventType:   "orders",
+				Version:     "0.1.0",
+				Application: "core-app",
+				MessageID:   "2",
+			},
+			Data: []byte(`{"value_one": "three", "value_two": "four"}`),
+		},
+	}
+
+	return events
+}
+
+type eventBusMock struct {
+	errPull, errStream, errSubscribe error
+	messageChannel                   string
+	events                           []messages.Event
+	eventStream                      chan messages.Event
+}
+
+func (e *eventBusMock) withEventStream() *eventBusMock {
+	e.eventStream = make(chan messages.Event)
+
+	return e
+}
+
+func (e *eventBusMock) withSubscribeError(err error) *eventBusMock {
+	e.errSubscribe = err
+
+	return e
+}
+
+func (e *eventBusMock) withPullError(err error) *eventBusMock {
+	e.errPull = err
+
+	return e
+}
+
+func (e *eventBusMock) withEvents(events []messages.Event) *eventBusMock {
+	e.events = events
+
+	return e
+}
+
+func (e *eventBusMock) Subscribe(_ context.Context, channel string) error {
+	if e.errSubscribe != nil {
+		return fmt.Errorf("%w", e.errSubscribe)
+	}
+
+	e.messageChannel = channel
+
+	return nil
+}
+
+func (e *eventBusMock) Pull(_ context.Context, _ uint8) ([]messages.Event, error) {
+	if e.errPull != nil {
+		return nil, fmt.Errorf("%w", e.errPull)
+	}
+
+	return e.events, nil
+}
+
+func (e *eventBusMock) Stream(ctx context.Context) (<-chan messages.Event, error) {
+	if e.eventStream == nil {
+		return nil, errStreamNotInitialized
+	}
+
+	go func() {
+		defer close(e.eventStream)
+
+		for _, event := range e.events {
+			select {
+			case <-ctx.Done():
+				return
+			case e.eventStream <- event:
+			}
+		}
+	}()
+
+	return e.eventStream, nil
+}
+
+func (e *eventBusMock) Acknowledge(ctx context.Context, id string) error {
+	return nil
+}


### PR DESCRIPTION
* problem: we need to publish and subscribe messages to and from our event bus. The idea is to reduce complexity in our. microservices when they need to publish and subscribe too.
* solution: build a pubsub library.